### PR TITLE
xiaomi13: Fixup persistent light appears after fp authentication fail

### DIFF
--- a/udfps/UdfpsHandler.cpp
+++ b/udfps/UdfpsHandler.cpp
@@ -127,6 +127,11 @@ class XiaomiSm8550UdfpsHander : public UdfpsHandler {
              * vendorCode = 22/23 waiting for fingerprint enroll
              */
             setFodStatus(FOD_STATUS_ON);
+        } else if (mSku == "fuxi" && vendorCode == 44){ 
+            /*
+             * (fuxi) vendorCode = 44 authentication fail
+             */
+            setFingerDown(false);
         }
     }
 


### PR DESCRIPTION
Through summarizing some logs, I attempted to understand the meaning of vendor code: 

- vendor code=20  waiting for fingerprint authentication 

- vendor code=22  waiting for fingerprint enroll ( if press duration is too short，code 22 won't appear)

- vendor code=0    authentication success（acquireInfo must also be 0）

- vendor code=31  enroll fail (won't cause light appearing)

- vendor code=44  authentication fail

- vendor code=23  authentication ends and finger lifts

- vendor code=21 lock from home screen 

I believe adding a conditional check for code 44 can effectively resolve persistent light appearing.